### PR TITLE
hotfix - making it work on stretch and ditching wheezy/jessie distros

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,25 +1,31 @@
-echo "Checking if code name distribution is jessie"
-CODE_NAME_DIST="$(lsb_release --codename)"
-if [[ $CODE_NAME_DIST != *"jessie" ]]; then
+#!/usr/bin/env bash
+
+# check https://www.linux-projects.org/uv4l/installation/ for more information
+# jessie/wheezy versions of UV4L are no longer maintained and hence
+# it's recommended to run this on a stretch
+
+echo "Checking if code name distribution is jessie/stretch"
+OS_CODENAME="$(lsb_release --codename --short)"
+if [[ $OS_CODENAME != "stretch" ]]; then
   echo "Code name distribution mismatch"
-  echo "Found "$CODE_NAME_DIST
+  echo "Only Stretch is supported - older versions like Jessie or Wheezy are no longer maintained"
   exit 1
-else
-  echo "Found jessie distribution"
 fi
+
+echo "Found $OS_CODENAME distribution"
 
 echo "Adding repository location for UV4L"
 curl -s http://www.linux-projects.org/listing/uv4l_repo/lrkey.asc | sudo apt-key add - > /dev/null
-if grep -q "[# ]*deb http://www.linux-projects.org/listing/uv4l_repo/raspbian/ jessie main" /etc/apt/sources.list
+if grep -q "[# ]*deb http://www.linux-projects.org/listing/uv4l_repo/raspbian/stretch stretch main" /etc/apt/sources.list
 then
-    sed -i '/deb http:\/\/www\.linux-projects\.org\/listing\/uv4l_repo\/raspbian\/ jessie main/s/^#//' /etc/apt/sources.list
+    sed -i '/deb http:\/\/www\.linux-projects\.org\/listing\/uv4l_repo\/raspbian\/stretch stretch main/s/^#//' /etc/apt/sources.list
 else
-    echo -e "deb http://www.linux-projects.org/listing/uv4l_repo/raspbian/ jessie main" >> /etc/apt/sources.list
+    echo -e "deb http://www.linux-projects.org/listing/uv4l_repo/raspbian/stretch stretch main" >> /etc/apt/sources.list
 fi
 
 
 echo "Updating repository"
-apt-get update > /dev/null
+apt-get update
 
 echo "Installing UV4L drivers"
 apt-get -y install uv4l uv4l-raspicam
@@ -33,4 +39,4 @@ echo "Restarting UV4L service"
 service uv4l_raspicam restart
 
 echo "Installing Flask"
-apt-get -y install python3-flask
+apt-get -y install python3-flask wiringpi


### PR DESCRIPTION
Fixes #7 issue. Originally I wanted to use the older versions for UV4L from Jessie sources, but then I found out there's support for Stretch distribution. 

Unfortunately for everyone else who's still using Jessie/Wheezy, UV4L is no longer maintained for these distributions, so you gotta use Stretch instead.

More information can be found here:
https://www.linux-projects.org/uv4l/installation/